### PR TITLE
Add rpc status to Futurenet terminal's prompt

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -15,6 +15,7 @@ RUN git clone https://github.com/tyvdh/soroban-quest--pioneer.git ~/.local/_tmp/
     mv ~/.local/_tmp/soroban-quest/_client ~/.local && \
     cd ~/.local/_tmp/soroban-quest/_squirtle && \
     mv bash-hook ~/.local && \
+    mv bash-rpc-prompt ~/.local && \
     npm run package && \
     cd ~/.local && \
     rm -rf ~/.local/_tmp

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -24,6 +24,7 @@ tasks:
       SOROBAN_NETWORK_PASSPHRASE: "Test SDF Future Network ; October 2022"
     command: |
       source ~/.local/bash-hook
+      source ~/.local/bash-rpc-prompt
       clear
   - name: CLI - Sandbox
     init: |


### PR DESCRIPTION
The terminal will look like this, then.
```
⏳ gitpod /workspace/soroban-quest (main) $ sq rpc
📡 Your local RPC endpoint is ready!
📡 gitpod /workspace/soroban-quest (main) $
```

Depends on https://github.com/tyvdh/soroban-quest--pioneer/pull/20


<a href="https://gitpod.io/#https://github.com/tyvdh/soroban-quest/pull/7"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

