### PR TITLE
Allowing double-click to take place in Markdown previews

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,6 +4,7 @@
   "workbench.editorAssociations": {
     "*.md": "vscode.markdown.preview.editor"
   },
+  "markdown.preview.doubleClickToSwitchToEditor": false,
   "rust-analyzer.cargo.useRustcWrapperForBuildScripts": false,
   "deno.enable": true,
   "deno.unstable": true


### PR DESCRIPTION
I didn't know until disgracefully late that double-clicking text within a markdown preview would open the editor and take you to that location in the file... That must be incredibly annoying to our questers.

Sorry everyone!

Signed-off-by: Elliot Voris <elliot@voris.me>

<a href="https://gitpod.io/#https://github.com/tyvdh/soroban-quest/pull/13"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

