### PR TITLE
Removing cargo-watch from Dockerfile

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -6,7 +6,6 @@ RUN curl -L -o ~/.local/bin/soroban https://github.com/stellar/soroban-cli/relea
 RUN chmod +x ~/.local/bin/soroban
 RUN curl -L https://github.com/mozilla/sccache/releases/download/v0.3.0/sccache-v0.3.0-x86_64-unknown-linux-musl.tar.gz | tar xz --strip-components 1 -C ~/.local/bin sccache-v0.3.0-x86_64-unknown-linux-musl/sccache
 RUN chmod +x ~/.local/bin/sccache
-RUN curl -L https://github.com/watchexec/cargo-watch/releases/download/v8.1.2/cargo-watch-v8.1.2-x86_64-unknown-linux-gnu.tar.xz | tar xJ --strip-components 1 -C ~/.local/bin cargo-watch-v8.1.2-x86_64-unknown-linux-gnu/cargo-watch
 
 RUN curl -LO https://github.com/denoland/deno/releases/download/v1.26.2/deno-x86_64-unknown-linux-gnu.zip
 RUN unzip deno-x86_64-unknown-linux-gnu.zip -d ~/.local/bin


### PR DESCRIPTION
Without the Makefile, we don't have any need for it, and any dev depending on its presence will be comfortable getting it in their own preferred method.

<a href="https://gitpod.io/#https://github.com/tyvdh/soroban-quest/pull/18"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

